### PR TITLE
Improve logging of `peerAppData`

### DIFF
--- a/src/main/java/alkarn/github/io/sslengine/example/NioSslClient.java
+++ b/src/main/java/alkarn/github/io/sslengine/example/NioSslClient.java
@@ -183,7 +183,7 @@ public class NioSslClient extends NioSslPeer {
                     switch (result.getStatus()) {
                     case OK:
                         peerAppData.flip();
-                        log.debug("Server response: " + new String(peerAppData.array()));
+                        log.debug("Server response: " + peerAppDataAsString());
                         exitReadLoop = true;
                         break;
                     case BUFFER_OVERFLOW:

--- a/src/main/java/alkarn/github/io/sslengine/example/NioSslPeer.java
+++ b/src/main/java/alkarn/github/io/sslengine/example/NioSslPeer.java
@@ -7,6 +7,7 @@ import java.nio.BufferOverflowException;
 import java.nio.ByteBuffer;
 import java.nio.channels.SocketChannel;
 import java.security.KeyStore;
+import java.util.Arrays;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -378,4 +379,7 @@ public abstract class NioSslPeer {
         return trustFactory.getTrustManagers();
     }
 
+    protected String peerAppDataAsString() {
+        return new String(Arrays.copyOf(peerAppData.array(), peerAppData.limit()));
+    }
 }

--- a/src/main/java/alkarn/github/io/sslengine/example/NioSslServer.java
+++ b/src/main/java/alkarn/github/io/sslengine/example/NioSslServer.java
@@ -175,7 +175,7 @@ public class NioSslServer extends NioSslPeer {
                 switch (result.getStatus()) {
                 case OK:
                     peerAppData.flip();
-                    log.debug("Incoming message: " + new String(peerAppData.array()));
+                    log.debug("Incoming message: " + peerAppDataAsString());
                     break;
                 case BUFFER_OVERFLOW:
                     peerAppData = enlargeApplicationBuffer(engine, peerAppData);


### PR DESCRIPTION
Without this change output like this can be seen in the log:
```
2020-07-24 10:57:19 DEBUG NioSslServer - Incoming message: Hello from client4!!!lient!
```

Also the line is about 16K long which makes it rather untidy.